### PR TITLE
Refactor: Map DTOs to domain models

### DIFF
--- a/app/src/main/java/com/yeyosystem/recipe/data/model/IngredientDto.kt
+++ b/app/src/main/java/com/yeyosystem/recipe/data/model/IngredientDto.kt
@@ -7,7 +7,7 @@ data class IngredientDto(
     @SerializedName("name") val name: String,
     @SerializedName("quantity") val quantity: String
 ) {
-    fun toModel(): Ingredient {
+    fun toDomain(): Ingredient {
         return Ingredient(
             name = name,
             quantity = quantity

--- a/app/src/main/java/com/yeyosystem/recipe/data/model/RecipeDetailDto.kt
+++ b/app/src/main/java/com/yeyosystem/recipe/data/model/RecipeDetailDto.kt
@@ -6,13 +6,15 @@ import com.yeyosystem.recipe.domain.model.RecipeDetail
 data class RecipeDetailDto(
     @SerializedName("id") val id: Int,
     @SerializedName("description") val description: String,
-    @SerializedName("preparation") val preparation: String
+    @SerializedName("preparation") val preparation: String,
+    @SerializedName("ingredients") val ingredients: List<IngredientDto>
 ) {
     fun toDomain(): RecipeDetail {
         return RecipeDetail(
             id = id.toString(),
             description = description,
-            preparation = preparation
+            preparation = preparation,
+            ingredients = ingredients.map { it.toDomain() }
         )
     }
 }

--- a/app/src/main/java/com/yeyosystem/recipe/data/remote/RecipeApiService.kt
+++ b/app/src/main/java/com/yeyosystem/recipe/data/remote/RecipeApiService.kt
@@ -1,38 +1,17 @@
 package com.yeyosystem.recipe.data.remote
 
-import android.util.Log
 import com.yeyosystem.recipe.data.model.RecipeDetailDto
 import com.yeyosystem.recipe.data.model.RecipeDto
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class RecipeApiService @Inject constructor(private val client: HttpClient) {
 
-    suspend fun getRecipes(): List<RecipeDto> = withContext(Dispatchers.IO) {
-        return@withContext try {
-            client.get("/recipes").body<List<RecipeDto>>() // Ktor will use Gson to deserialize
-        } catch (e: Exception) {
-            Log.e("RecipeApiService", "Error al obtener recetas", e)
-            emptyList()
-        }
+    suspend fun getRecipes(): List<RecipeDto> {
+        return client.safeGet("/recipes") ?: emptyList()
     }
 
-    suspend fun getRecipeDetail(recipeId: String): RecipeDetailDto = withContext(Dispatchers.IO) {
-        val response: HttpResponse = client.get("/detail/$recipeId")
-        val json = response.bodyAsText()
-        println("WireMock Response: $json") // Depuración en consola
-
-        return@withContext try {
-            response.body()
-        } catch (e: Exception) {
-            println("Error parsing JSON: ${e.message}")
-            throw e
-        }
+    suspend fun getRecipeDetail(recipeId: String): RecipeDetailDto? {
+        return client.safeGet("/recipes/$recipeId")
     }
 }

--- a/app/src/main/java/com/yeyosystem/recipe/data/repository/RecipeRepositoryImpl.kt
+++ b/app/src/main/java/com/yeyosystem/recipe/data/repository/RecipeRepositoryImpl.kt
@@ -18,10 +18,6 @@ class RecipeRepositoryImpl @Inject constructor(
 
     override suspend fun getRecipeDetail(recipeId: String): RecipeDetail {
         val recipeDetail = apiService.getRecipeDetail(recipeId)
-        Log.d("RecipeDetail", "ID: ${recipeDetail.id}")
-        Log.d("RecipeDetail", "Description: ${recipeDetail.description}")
-        Log.d("RecipeDetail", "Preparation: ${recipeDetail.preparation}")
-
-        return recipeDetail.toDomain()
+        return recipeDetail?.toDomain() ?: RecipeDetail("0", "", "", emptyList())
     }
 }

--- a/app/src/main/java/com/yeyosystem/recipe/domain/model/RecipeDetail.kt
+++ b/app/src/main/java/com/yeyosystem/recipe/domain/model/RecipeDetail.kt
@@ -4,5 +4,5 @@ data class RecipeDetail(
     val id: String,
     val description: String,
     val preparation: String,
-    val ingredients: List<Ingredient> = emptyList()
+    val ingredients: List<Ingredient>
 )


### PR DESCRIPTION
- Changed `toModel` to `toDomain` in `IngredientDto` to better reflect its purpose.
- Added `ingredients` field to `RecipeDetailDto` and updated `toDomain` to map ingredients.
- Modified `getRecipeDetail` in `RecipeApiService` to use `safeGet` and return a nullable `RecipeDetailDto`.
- Updated `getRecipeDetail` in `RecipeRepositoryImpl` to handle null `RecipeDetailDto` and return a default `RecipeDetail`.
- Modified the `RecipeDetail` in the domain to take a list of ingredients.